### PR TITLE
Use gdate on OS X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,12 @@ WEBGL_VER ?= 2
 # Bash so we can use curly braces expansion
 SHELL = bash
 
+ifeq ($(shell uname),Darwin) # MacOS
+	date=gdate
+else
+	date=date
+endif
+
 #NOTE: Dynamic casts are disabled by fno-rtti
 CFLAGS = -pipe -I./engine -I./generated $(DEP_INCLUDE) -Wall -Wno-unused-parameter $(PROFILEFLAGS) $(DEBUGFLAGS) $(IMGUIFLAGS) -O$(strip $(OPTIM)) $(PLATFORM_CFLAGS)
 CXXFLAGS = $(CFLAGS) -std=c++17 -fno-rtti -fno-exceptions -Wno-reorder
@@ -108,9 +114,9 @@ run: $(EXEC)
 	@$(EXEC)
 
 define time_begin
-	@date +%s%3N > $(1).time
+	@$(date) +%s%3N > $(1).time
 endef
 
 define time_end
-	@echo "Built $(1) in $$(($$(date +%s%3N)-$$(cat $(1).time))) ms"
+	@echo "Built $(1) in $$(($$($(date) +%s%3N)-$$(cat $(1).time))) ms"
 endef


### PR DESCRIPTION
BSD date on OS X does not have something-second precision. This forces it to use GNU date.

Not ideal, but works I guess